### PR TITLE
remove redundant sentinel in pidfile name

### DIFF
--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -4,7 +4,7 @@
 <% if @job_control == 'initd' %>
 daemonize yes
 <% end %>
-pidfile <%= @piddir %>/sentinel_<%=@name%>.pid
+pidfile <%= @piddir %>/<%=@name%>.pid
 loglevel <%=@loglevel%>
 syslog-enabled <%= @syslogenabled %>
 syslog-ident redis-<%= @name %>


### PR DESCRIPTION
The @name used to create the sentinel pidfile already contains
"sentinel_name", so it ends up generating as
sentinel_sentinel_name.pid. This removes the redundancy.